### PR TITLE
fix: typing export

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,7 +31,8 @@
   "exports": {
     ".": {
       "import": "./dist/vitest-fail-on-console.es.js",
-      "require": "./dist/vitest-fail-on-console.umd.js"
+      "require": "./dist/vitest-fail-on-console.umd.js",
+      "types": "./dist/index.d.ts"
     }
   },
   "types": "./dist/index.d.ts",
@@ -58,6 +59,5 @@
   "dependencies": {
     "chalk": "^5.2.0",
     "node-stdlib-browser": "^1.2.0"
-
   }
 }


### PR DESCRIPTION
resolves #10

### Related to
Issue #10 

### Notes
This fixes the problem where the types can not be imported in typescript projects with newer moduleResolution modes.
The problem was that the types are only specified at the root level, but are missing in the `exports` area of package.json.

### Types of changes
-   [x]   :bug: Bug fix
-   [ ]   :boom: Breaking change
-   [ ]   :sparkles: New feature
-   [ ]   :recycle: Refactoring
-   [ ]   :book: Documentation


### Maintainability & Security
-   [x]   🧪  unit test



