### PR TITLE
feat: add afterEachDelay option

### DIFF
--- a/README.md
+++ b/README.md
@@ -188,6 +188,19 @@ failOnConsole({
 })
 ```
 
+### afterEachDelay
+
+Use this to make sure test fails even when the console warning is called after the test finished executing. This is useful for debugging flaky tests. It's recommended to turn it off for CI (or set it to a low value) as it will slow down test execution
+
+- Type: `number`
+- Default: `0`
+
+```ts
+failOnConsole({
+  afterEachDelay: !process.env.CI ? 1000 : 0,
+})
+```
+
 ## License
 
 [MIT](https://github.com/thomasbroduch/vitest-fail-on-console/blob/develop/LICENSE)

--- a/src/index.ts
+++ b/src/index.ts
@@ -29,6 +29,7 @@ const init = (
         shouldFailOnWarn = true,
         skipTest = undefined,
         silenceMessage = undefined,
+        afterEachDelay = undefined
     }: VitestFailOnConsoleFunction = {
         errorMessage: defaultErrorMessage,
         shouldFailOnAssert: false,
@@ -39,6 +40,7 @@ const init = (
         shouldFailOnWarn: true,
         silenceMessage: undefined,
         skipTest: undefined,
+        afterEachDelay: undefined
     }
 ) => {
     const flushUnexpectedConsoleCalls = (
@@ -127,9 +129,12 @@ const init = (
             unexpectedConsoleCallStacks.length = 0;
         });
 
-        afterEach(() => {
+        afterEach(async () => {
             if (isTestSkipped()) {
                 return;
+            }
+            if (afterEachDelay) {
+                await new Promise(resolve => setTimeout(resolve, afterEachDelay));
             }
             flushUnexpectedConsoleCalls(
                 methodName,

--- a/src/types.ts
+++ b/src/types.ts
@@ -34,4 +34,5 @@ export type VitestFailOnConsoleFunction = {
     skipTest?: SkipTestFunction;
     errorMessage?: ErrorMessageFunction;
     silenceMessage?: SilenceMessageFunction;
+    afterEachDelay?: number;
 };

--- a/tests/fixtures/after-each-delay-failure/index.spec.ts
+++ b/tests/fixtures/after-each-delay-failure/index.spec.ts
@@ -1,0 +1,7 @@
+import consoleError from './index';
+import { describe, it, expect } from 'vitest';
+describe('console.error with timeout', () => {
+    it('does throw', () => {
+        expect(consoleError).toThrow();
+    });
+});

--- a/tests/fixtures/after-each-delay-failure/index.ts
+++ b/tests/fixtures/after-each-delay-failure/index.ts
@@ -1,0 +1,2 @@
+export default () =>
+    setTimeout(() => console.error('this is an error message'), 100);

--- a/tests/fixtures/after-each-delay-failure/vitest.config.ts
+++ b/tests/fixtures/after-each-delay-failure/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+    test: {
+        environment: 'node',
+        globals: true,
+        setupFiles: [
+            './tests/fixtures/after-each-delay-failure/vitest.setup.ts',
+        ],
+    },
+});

--- a/tests/fixtures/after-each-delay-failure/vitest.setup.ts
+++ b/tests/fixtures/after-each-delay-failure/vitest.setup.ts
@@ -1,0 +1,2 @@
+import vitestFailOnConsole from '../../../src/index';
+vitestFailOnConsole({ afterEachDelay: 100 });

--- a/tests/fixtures/after-each-delay-success/index.spec.ts
+++ b/tests/fixtures/after-each-delay-success/index.spec.ts
@@ -1,0 +1,7 @@
+import consoleError from './index';
+import { describe, it, expect } from 'vitest';
+describe('console.error with timeout', () => {
+    it('does not throw', () => {
+        expect(consoleError).not.toThrow();
+    });
+});

--- a/tests/fixtures/after-each-delay-success/index.ts
+++ b/tests/fixtures/after-each-delay-success/index.ts
@@ -1,0 +1,2 @@
+export default () =>
+    setTimeout(() => console.error('this is an error message'), 100);

--- a/tests/fixtures/after-each-delay-success/vitest.config.ts
+++ b/tests/fixtures/after-each-delay-success/vitest.config.ts
@@ -1,0 +1,10 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+    test: {
+        environment: 'node',
+        globals: true,
+        setupFiles: [
+            './tests/fixtures/after-each-delay-success/vitest.setup.ts',
+        ],
+    },
+});

--- a/tests/fixtures/after-each-delay-success/vitest.setup.ts
+++ b/tests/fixtures/after-each-delay-success/vitest.setup.ts
@@ -1,0 +1,2 @@
+import vitestFailOnConsole from '../../../src/index';
+vitestFailOnConsole();

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -47,6 +47,20 @@ describe('vitest-fail-on-console', () => {
             'assert-success',
             false,
         ],
+        [
+            'throw error',
+            'console.error() is called in setTimeout()',
+            { afterEachDelay: 100 },
+            'after-each-delay-failure',
+            true,
+        ],
+        [
+            'not throw error',
+            'console.error() is called in setTimeout()',
+            {},
+            'after-each-delay-success',
+            false,
+        ],
     ])(
         'should %s when %s with options %s',
         async (msgA, msgB, options, fixture, isErrorThrown) => {


### PR DESCRIPTION
### Related to
No issue

### Notes
Added an option to delay flushing unexpected console calls to make it easier to identify tests that are written poorly (e.g. didn't clean up properly)

### Types of changes
-   [ ]   :bug: Bug fix
-   [ ]   :boom: Breaking change
-   [x]   :sparkles: New feature
-   [ ]   :recycle: Refactoring
-   [ ]   :book: Documentation


### Maintainability & Security
-   [x]   🧪  unit test



