### PR TITLE
fix: vitest as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,11 +53,14 @@
     "typescript": "^4.9.4",
     "vite": "4.3.9",
     "vite-plugin-dts": "^1.7.1",
-    "vite-plugin-node-stdlib-browser": "^0.2.1"
+    "vite-plugin-node-stdlib-browser": "^0.2.1",
+    "vitest": "0.26.2"
   },
   "dependencies": {
-    "vitest": "^0.26.2",
     "chalk": "^5.2.0",
     "node-stdlib-browser": "^1.2.0"
+  },
+  "peerDependencies": {
+    "vitest": ">=0.26.2"
   }
 }


### PR DESCRIPTION
### Related to
~Issue #XXX~

### Notes

I believe this package should qualify as a "plugin" for vitest as described in [npm peer dependencies](https://nodejs.org/en/blog/npm/peer-dependencies). Using version 0.5.1 of vitest-fail-on-console in my project caused two versions of vitest to be installed.

I tested with my project to verify this change will allow vitest to be de-duped

With 0.5.1:
```
% npm ls vitest
├─┬ @testing-library/jest-dom@6.1.3
│ └── vitest@0.34.5 deduped
├─┬ @vitest/coverage-istanbul@0.34.5
│ └── vitest@0.34.5 deduped
├─┬ @vitest/ui@0.34.5
│ └── vitest@0.34.5 deduped
├─┬ vitest-fail-on-console@0.5.1
│ └── vitest@0.26.3
└── vitest@0.34.5
```

With this branch:

```
% npm ls vitest
├─┬ @testing-library/jest-dom@6.1.2
│ └── vitest@0.34.3 deduped
├─┬ @vitest/coverage-istanbul@0.34.3
│ └── vitest@0.34.3 deduped
├─┬ @vitest/ui@0.34.3
│ └── vitest@0.34.3 deduped
├─┬ vitest-fail-on-console@0.5.2 (git+ssh://git@github.com/justintoman/vitest-fail-on-console.git#0a03a9b53d76955a4a69b6fc1c6bc464c5b015e3)
│ └── vitest@0.34.3 deduped
└── vitest@0.34.3
```

### Types of changes
-   [x]   :bug: Bug fix
-   [ ]   :boom: Breaking change
-   [ ]   :sparkles: New feature
-   [ ]   :recycle: Refactoring
-   [ ]   :book: Documentation


### Maintainability & Security
-   [ ]   🧪  unit test



