### PR TITLE
fix: add imports from vitest

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,3 +1,4 @@
+import { beforeEach, afterEach, expect } from "vitest";
 import * as util from 'util';
 import chalk from 'chalk';
 import {


### PR DESCRIPTION
### Related to
Issue #18

### Notes
Adds unreferenced but used `beforeEach`, `afterEach` and `expect` imports from "vitest"

### Types of changes
-   [x]   :bug: Bug fix
-   [ ]   :boom: Breaking change
-   [ ]   :sparkles: New feature
-   [ ]   :recycle: Refactoring
-   [ ]   :book: Documentation


### Maintainability & Security
-   [ ]   🧪  unit test
