### PR TITLE
feat: do not capture log messages

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -22,8 +22,6 @@ export enum ConsoleMethod {
     Warn = 'warn',
 }
 
-export type ConsoleCallStacks = [string, string][];
-
 export type VitestFailOnConsoleFunction = {
     shouldFailOnAssert?: boolean;
     shouldFailOnDebug?: boolean;

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -10,7 +10,7 @@ describe('vitest-fail-on-console', () => {
         const configFilePath = `${fixtureDirectory}/vitest.config.ts`;
         const cmd = `./node_modules/.bin/vitest related ${testFilePath} -c ${configFilePath} --run`;
         return new Promise((resolve) => {
-            exec(cmd, (error, stdout, stderr) => {
+            exec(cmd, (_error, _stdout, stderr) => {
                 resolve({ stderr });
             });
         });


### PR DESCRIPTION
### Related to

See https://github.com/thomasbrodusch/vitest-fail-on-console/issues/61

### Notes

In the above issue I advocated for not capturing the log messages, letting them through naturally.
Then, I proposed two options:
-  After the test is complete, throw error saying that console messages appeared - this PR implements this approach
-  After the test is complete, throw error saying that console messages appeared, and print the messages again - this is implemented in https://github.com/thomasbrodusch/vitest-fail-on-console/pull/70

### Types of changes
-   [ ]   :bug: Bug fix
-   [ ]   :boom: Breaking change
-   [x]   :sparkles: New feature
-   [ ]   :recycle: Refactoring
-   [ ]   :book: Documentation


### Maintainability & Security

- [x] Verified that unit tests in this package are passing
- [x] Verified this branch of vitest-fail-on-console on my personal vitest node.js and vitest browser tests to make sure it works correctly



