### PR TITLE
feat: do not prevent native console log

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,4 @@
-import { beforeEach, afterEach, expect } from "vitest";
+import { beforeEach, afterEach, expect } from 'vitest';
 import * as util from 'util';
 import chalk from 'chalk';
 import {
@@ -29,7 +29,7 @@ const init = (
         shouldFailOnWarn = true,
         skipTest = undefined,
         silenceMessage = undefined,
-        afterEachDelay = undefined
+        afterEachDelay = undefined,
     }: VitestFailOnConsoleFunction = {
         errorMessage: defaultErrorMessage,
         shouldFailOnAssert: false,
@@ -40,7 +40,7 @@ const init = (
         shouldFailOnWarn: true,
         silenceMessage: undefined,
         skipTest: undefined,
-        afterEachDelay: undefined
+        afterEachDelay: undefined,
     }
 ) => {
     const flushUnexpectedConsoleCalls = (
@@ -83,6 +83,8 @@ const init = (
             if (silenceMessage && silenceMessage(message, methodName)) {
                 return;
             }
+
+            originalMethod(message);
 
             // Capture the call stack now, so we can warn about it later.
             // The call stack has helpful information for the test author.
@@ -134,7 +136,9 @@ const init = (
                 return;
             }
             if (afterEachDelay) {
-                await new Promise(resolve => setTimeout(resolve, afterEachDelay));
+                await new Promise((resolve) =>
+                    setTimeout(resolve, afterEachDelay)
+                );
             }
             flushUnexpectedConsoleCalls(
                 methodName,


### PR DESCRIPTION
### Related to

See https://github.com/thomasbrodusch/vitest-fail-on-console/issues/61

### Notes

In the above issue I advocated for not capturing the log messages, letting them through naturally.
Then, I proposed two options:
-  After the test is complete, throw error saying that console messages appeared - this is implemented in https://github.com/thomasbrodusch/vitest-fail-on-console/pull/69
-  After the test is complete, throw error saying that console messages appeared, and print the messages again - this PR implements this approach

### Types of changes
-   [ ]   :bug: Bug fix
-   [ ]   :boom: Breaking change
-   [x]   :sparkles: New feature
-   [ ]   :recycle: Refactoring
-   [ ]   :book: Documentation


### Maintainability & Security

- [x] Verified that unit tests in this package are passing
- [x] Verified this branch of vitest-fail-on-console on my personal vitest node.js and vitest browser tests to make sure it works correctly



