### PR TITLE
fix: add main to package.json for backward compatibility

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "files": [
     "dist"
   ],
+  "main": "./dist/vitest-fail-on-console.es.js",
   "exports": {
     ".": {
       "types": "./dist/index.d.ts",


### PR DESCRIPTION
### Related to
[Eslint plugin import](https://github.com/import-js/eslint-plugin-import) throws the error "Unable to resolve path to module 'vitest-fail-on-console'" so the "main" field was added to package.json for backward compatibility that fixes the problem.

![Screenshot 2025-01-09 180932](https://github.com/user-attachments/assets/cb27982b-e460-4e1d-b26b-f71651ef216a)


### Types of changes
-   [x]   :bug: Bug fix


