### PR TITLE
feat: add allowMessage option

### DIFF
--- a/README.md
+++ b/README.md
@@ -136,6 +136,32 @@ Use this to make a test fail when a `console.warn()` is logged.
 - Type: `boolean`
 - Default: `true`
 
+### allowMessage
+
+```ts
+// signature
+type allowMessage = (
+  message: string,
+  methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn',
+) => boolean
+```
+
+This function is called for every console method supported by this utility.
+If `true` is returned, the message will show in the console and the test won't fail.
+
+Example:
+
+```ts
+failOnConsole({
+  allowMessage: (errorMessage) => {
+    if (/An expected error/.test(errorMessage)) {
+      return true
+    }
+    return false
+  },
+})
+```
+
 ### silenceMessage
 
 ```ts

--- a/src/index.ts
+++ b/src/index.ts
@@ -28,6 +28,7 @@ const init = (
         shouldFailOnLog = false,
         shouldFailOnWarn = true,
         skipTest = undefined,
+        allowMessage = undefined,
         silenceMessage = undefined,
         afterEachDelay = undefined
     }: VitestFailOnConsoleFunction = {
@@ -38,6 +39,7 @@ const init = (
         shouldFailOnInfo: false,
         shouldFailOnLog: false,
         shouldFailOnWarn: true,
+        allowMessage: undefined,
         silenceMessage: undefined,
         skipTest: undefined,
         afterEachDelay: undefined
@@ -81,6 +83,11 @@ const init = (
         const captureMessage = (format: unknown, ...args) => {
             const message = util.format(format, ...args);
             if (silenceMessage && silenceMessage(message, methodName)) {
+                return;
+            }
+
+            if (allowMessage && allowMessage(message, methodName)) {
+                originalMethod(format, ...args);
                 return;
             }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -8,6 +8,11 @@ type SkipTestFunction = ({
 
 type ErrorMessageFunction = (methodName: ConsoleMethod) => string;
 
+type AllowMessageFunction = (
+    message: string,
+    methodName: ConsoleMethod
+) => boolean;
+
 type SilenceMessageFunction = (
     message: string,
     methodName: ConsoleMethod
@@ -33,6 +38,7 @@ export type VitestFailOnConsoleFunction = {
     shouldFailOnWarn?: boolean;
     skipTest?: SkipTestFunction;
     errorMessage?: ErrorMessageFunction;
+    allowMessage?: AllowMessageFunction;
     silenceMessage?: SilenceMessageFunction;
     afterEachDelay?: number;
 };

--- a/tests/fixtures/allow-message-false/index.spec.ts
+++ b/tests/fixtures/allow-message-false/index.spec.ts
@@ -1,0 +1,7 @@
+import consoleError from './index';
+import { describe, it, expect } from 'vitest';
+describe('console.error allow message false', () => {
+    it('does throw', () => {
+        expect(consoleError).toThrow();
+    });
+});

--- a/tests/fixtures/allow-message-false/index.ts
+++ b/tests/fixtures/allow-message-false/index.ts
@@ -1,0 +1,1 @@
+export default () => console.error('error message');

--- a/tests/fixtures/allow-message-false/vitest.config.ts
+++ b/tests/fixtures/allow-message-false/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+    test: {
+        environment: 'node',
+        globals: true,
+        setupFiles: ['./tests/fixtures/allow-message-false/vitest.setup.ts'],
+    },
+});

--- a/tests/fixtures/allow-message-false/vitest.setup.ts
+++ b/tests/fixtures/allow-message-false/vitest.setup.ts
@@ -1,0 +1,5 @@
+import vitestFailOnConsole from '../../../src/index';
+
+vitestFailOnConsole({
+    silenceMessage: (errorMessage) => /allow message/.test(errorMessage),
+});

--- a/tests/fixtures/allow-message-true/index.spec.ts
+++ b/tests/fixtures/allow-message-true/index.spec.ts
@@ -1,0 +1,7 @@
+import consoleError from './index';
+import { describe, it, expect } from 'vitest';
+describe('console.error allow message true', () => {
+    it('does not throw', () => {
+        expect(consoleError).not.toThrow();
+    });
+});

--- a/tests/fixtures/allow-message-true/index.ts
+++ b/tests/fixtures/allow-message-true/index.ts
@@ -1,0 +1,1 @@
+export default () => console.error('allow message');

--- a/tests/fixtures/allow-message-true/vitest.config.ts
+++ b/tests/fixtures/allow-message-true/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+    test: {
+        environment: 'node',
+        globals: true,
+        setupFiles: ['./tests/fixtures/allow-message-true/vitest.setup.ts'],
+    },
+});

--- a/tests/fixtures/allow-message-true/vitest.setup.ts
+++ b/tests/fixtures/allow-message-true/vitest.setup.ts
@@ -1,0 +1,5 @@
+import vitestFailOnConsole from '../../../src/index';
+
+vitestFailOnConsole({
+    silenceMessage: (errorMessage) => /allow message/.test(errorMessage),
+});

--- a/tests/fixtures/silence-message-false/index.spec.ts
+++ b/tests/fixtures/silence-message-false/index.spec.ts
@@ -1,0 +1,7 @@
+import consoleError from './index';
+import { describe, it, expect } from 'vitest';
+describe('console.error silence message false', () => {
+    it('does throw', () => {
+        expect(consoleError).toThrow();
+    });
+});

--- a/tests/fixtures/silence-message-false/index.ts
+++ b/tests/fixtures/silence-message-false/index.ts
@@ -1,0 +1,1 @@
+export default () => console.error('error message');

--- a/tests/fixtures/silence-message-false/vitest.config.ts
+++ b/tests/fixtures/silence-message-false/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+    test: {
+        environment: 'node',
+        globals: true,
+        setupFiles: ['./tests/fixtures/silence-message-false/vitest.setup.ts'],
+    },
+});

--- a/tests/fixtures/silence-message-false/vitest.setup.ts
+++ b/tests/fixtures/silence-message-false/vitest.setup.ts
@@ -1,0 +1,5 @@
+import vitestFailOnConsole from '../../../src/index';
+
+vitestFailOnConsole({
+    silenceMessage: (errorMessage) => /silence message/.test(errorMessage),
+});

--- a/tests/fixtures/silence-message-true/index.spec.ts
+++ b/tests/fixtures/silence-message-true/index.spec.ts
@@ -1,0 +1,7 @@
+import consoleError from './index';
+import { describe, it, expect } from 'vitest';
+describe('console.error silence message true', () => {
+    it('does not throw', () => {
+        expect(consoleError).not.toThrow();
+    });
+});

--- a/tests/fixtures/silence-message-true/index.ts
+++ b/tests/fixtures/silence-message-true/index.ts
@@ -1,0 +1,1 @@
+export default () => console.error('silence message');

--- a/tests/fixtures/silence-message-true/vitest.config.ts
+++ b/tests/fixtures/silence-message-true/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+    test: {
+        environment: 'node',
+        globals: true,
+        setupFiles: ['./tests/fixtures/silence-message-true/vitest.setup.ts'],
+    },
+});

--- a/tests/fixtures/silence-message-true/vitest.setup.ts
+++ b/tests/fixtures/silence-message-true/vitest.setup.ts
@@ -1,0 +1,5 @@
+import vitestFailOnConsole from '../../../src/index';
+
+vitestFailOnConsole({
+    silenceMessage: (errorMessage) => /silence message/.test(errorMessage),
+});

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -61,6 +61,24 @@ describe('vitest-fail-on-console', () => {
             'after-each-delay-success',
             false,
         ],
+        [
+            'throw error',
+            'console.error() is called',
+            {
+                silenceMessage: () => false,
+            },
+            'silence-message-false',
+            true,
+        ],
+        [
+            'not throw error',
+            'console.error() is called',
+            {
+                silenceMessage: () => true,
+            },
+            'silence-message-true',
+            false,
+        ],
     ])(
         'should %s when %s with options %s',
         async (msgA, msgB, options, fixture, isErrorThrown) => {

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -79,6 +79,24 @@ describe('vitest-fail-on-console', () => {
             'silence-message-true',
             false,
         ],
+        [
+            'throw error',
+            'console.error() is called',
+            {
+                allowMessage: () => false,
+            },
+            'allow-message-false',
+            true,
+        ],
+        [
+            'not throw error',
+            'console.error() is called',
+            {
+                allowMessage: () => true,
+            },
+            'allow-message-true',
+            false,
+        ],
     ])(
         'should %s when %s with options %s',
         async (msgA, msgB, options, fixture, isErrorThrown) => {


### PR DESCRIPTION
### Related to
Adds `allowMessage` option

### Notes
This PR adds `allowMessage` option similar to [jest-fail-on-console](https://github.com/ValentinH/jest-fail-on-console/tree/main?tab=readme-ov-file#allowmessage).
`allowMessage` implementation in jest-fail-on-console: https://github.com/ValentinH/jest-fail-on-console/blob/main/index.js#L69

It will allow tests to pass while logging helpful error messages in console.
For example: 
When using [`msw`](https://mswjs.io/), it logs errors like following to help developers about missing request handlers. Currently, this type of helpful error message can not be displayed when using vitest-fail-on-console.

> [MSW] Error: intercepted a request without a matching request handler:
>   • GET /v1/examples/234


### Types of changes
-   [ ]   :bug: Bug fix
-   [ ]   :boom: Breaking change
-   [x]   :sparkles: New feature
-   [ ]   :recycle: Refactoring
-   [ ]   :book: Documentation


### Maintainability & Security
-   [x]   🧪  unit test



