### PR TITLE
chore: do not publish test files

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,8 @@
   "license": "MIT",
   "type": "module",
   "files": [
-    "dist"
+    "dist",
+    "!dist/tests"
   ],
   "main": "./dist/vitest-fail-on-console.es.js",
   "exports": {


### PR DESCRIPTION
### Notes
I noticed that the dist/tests folder was also published with the npm package, but that's not relevant for the end-user. So this PR removes that from the package.

You can see the difference by running `npm pack` (optionally with `--dry-run`)

### Types of changes
-   [ ]   :bug: Bug fix
-   [ ]   :boom: Breaking change
-   [ ]   :sparkles: New feature
-   [ ]   :recycle: Refactoring
-   [ ]   :book: Documentation
-   [X]  Other



