### PR TITLE
issue-115-remove-node-dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
     "prebuild": "rm -rf dist",
     "build": "vite build",
     "lint": "yarn eslint .",
-    "test": "vitest related ./tests/index.spec.ts --run",
+    "test": "yarn playwright install && yarn test:only",
+    "test:only": "vitest related ./tests/index.spec.ts --run",
     "release": "standard-version",
     "release:patch": "standard-version --release-as patch",
     "release:minor": "standard-version --release-as minor",
@@ -45,9 +46,11 @@
     "@commitlint/cli": "19.8.1",
     "@commitlint/config-conventional": "19.8.1",
     "@eslint/js": "^9.32.0",
+    "@vitest/browser": "3.2.4",
     "eslint": "^9.32.0",
     "globals": "^16.3.0",
     "husky": "9.1.7",
+    "playwright": "^1.55.0",
     "prettier": "3.6.2",
     "standard-version": "9.5.0",
     "typescript": "5.8.3",
@@ -60,6 +63,7 @@
     "chalk": "^5.4.1"
   },
   "peerDependencies": {
+    "@vitest/util": ">=0.26.2",
     "vite": ">=4.5.2",
     "vitest": ">=0.26.2"
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,6 @@
 import { beforeEach, afterEach, expect } from "vitest";
-import * as util from 'util';
 import chalk from 'chalk';
+import { format as vitestFormat } from "@vitest/utils"
 import {
     ConsoleCallStacks,
     ConsoleMethod,
@@ -82,7 +82,7 @@ const init = (
         const unexpectedConsoleCallStacks: ConsoleCallStacks = [];
 
         const captureMessage = (format: unknown, ...args) => {
-            const message = util.format(format, ...args);
+            const message = vitestFormat(format, ...args);
             if (silenceMessage && silenceMessage(message, methodName)) {
                 return;
             }

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -4,128 +4,131 @@ describe('vitest-fail-on-console', () => {
     const errorThrownMessage = () =>
         `vitest-fail-on-console > Expected test not to call`;
 
-    const runFixture = async (fixtureName): Promise<{ stderr: string }> => {
+    const runFixture = async (fixtureName: string, args: string): Promise<{ stderr: string }> => {
         const fixtureDirectory = `./tests/fixtures/${fixtureName}/`;
         const testFilePath = `${fixtureDirectory}/index.spec.ts`;
         const configFilePath = `${fixtureDirectory}/vitest.config.ts`;
-        const cmd = `./node_modules/.bin/vitest related ${testFilePath} -c ${configFilePath} --run`;
+        const cmd = `./node_modules/.bin/vitest related ${testFilePath} -c ${configFilePath} --run ${args}`;
         return new Promise((resolve) => {
             exec(cmd, (error, stdout, stderr) => {
                 resolve({ stderr });
             });
         });
     };
+    describe.each(["", "--browser.headless"] as const)("with additional args \"%s\"", (args) => {
+        it.each([
+            ['throw error', 'console.error() is called', {}, 'error', true],
 
-    it.each([
-        ['throw error', 'console.error() is called', {}, 'error', true],
+            [
+                'not throw error',
+                'console.error() is called',
+                { shouldFailOnError: false },
+                'error-disabled',
+                false,
+            ],
+            [
+                'not throw error',
+                'console.error() is called',
+                { shouldFailOnError: true, skipTest: '/pattern/' },
+                'error-skip-test',
+                false,
+            ],
+            [
+                'throw error',
+                'console.assert() is called with a failing assertion ',
+                { shouldFailOnAssert: true },
+                'assert-failure',
+                true,
+            ],
+            [
+                'not throw error',
+                'console.assert() is called with a passing assertion',
+                { shouldFailOnAssert: true },
+                'assert-success',
+                false,
+            ],
+            [
+                'throw error',
+                'console.error() is called in setTimeout()',
+                { afterEachDelay: 100 },
+                'after-each-delay-failure',
+                true,
+            ],
+            [
+                'not throw error',
+                'console.error() is called in setTimeout()',
+                {},
+                'after-each-delay-success',
+                false,
+            ],
+            [
+                'throw error',
+                'console.error() is called',
+                {
+                    silenceMessage: () => false,
+                },
+                'silence-message-false',
+                true,
+            ],
+            [
+                'not throw error',
+                'console.error() is called',
+                {
+                    silenceMessage: () => true,
+                },
+                'silence-message-true',
+                false,
+            ],
+            [
+                'throw error',
+                'console.error() is called',
+                {
+                    allowMessage: () => false,
+                },
+                'allow-message-false',
+                true,
+            ],
+            [
+                'not throw error',
+                'console.error() is called',
+                {
+                    allowMessage: () => true,
+                },
+                'allow-message-true',
+                false,
+            ],
+            [
+                'throw error',
+                'console.error() is called',
+                {
+                    shouldFailOnError: () => true,
+                    shouldPrintMessage: () => true,
+                },
+                'should-print-message-error',
+                true,
+            ],
+            [
+                'not throw error',
+                'console.error() is called',
+                {
+                    shouldFailOnError: () => false,
+                    shouldPrintMessage: () => true,
+                },
+                'should-print-message-no-error',
+                false,
+            ],
+        ])(
+            'should %s when %s with options %s',
+            async (msgA, msgB, options, fixture, isErrorThrown) => {
+                const { stderr } = await runFixture(fixture, args);
+                expect(stderr).toEqual(
+                    isErrorThrown
+                        ? expect.stringContaining(errorThrownMessage())
+                        : expect.not.stringContaining(errorThrownMessage())
+                );
+            }
+        );
 
-        [
-            'not throw error',
-            'console.error() is called',
-            { shouldFailOnError: false },
-            'error-disabled',
-            false,
-        ],
-        [
-            'not throw error',
-            'console.error() is called',
-            { shouldFailOnError: true, skipTest: '/pattern/' },
-            'error-skip-test',
-            false,
-        ],
-        [
-            'throw error',
-            'console.assert() is called with a failing assertion ',
-            { shouldFailOnAssert: true },
-            'assert-failure',
-            true,
-        ],
-        [
-            'not throw error',
-            'console.assert() is called with a passing assertion',
-            { shouldFailOnAssert: true },
-            'assert-success',
-            false,
-        ],
-        [
-            'throw error',
-            'console.error() is called in setTimeout()',
-            { afterEachDelay: 100 },
-            'after-each-delay-failure',
-            true,
-        ],
-        [
-            'not throw error',
-            'console.error() is called in setTimeout()',
-            {},
-            'after-each-delay-success',
-            false,
-        ],
-        [
-            'throw error',
-            'console.error() is called',
-            {
-                silenceMessage: () => false,
-            },
-            'silence-message-false',
-            true,
-        ],
-        [
-            'not throw error',
-            'console.error() is called',
-            {
-                silenceMessage: () => true,
-            },
-            'silence-message-true',
-            false,
-        ],
-        [
-            'throw error',
-            'console.error() is called',
-            {
-                allowMessage: () => false,
-            },
-            'allow-message-false',
-            true,
-        ],
-        [
-            'not throw error',
-            'console.error() is called',
-            {
-                allowMessage: () => true,
-            },
-            'allow-message-true',
-            false,
-        ],
-        [
-            'throw error',
-            'console.error() is called',
-            {
-                shouldFailOnError: () => true,
-                shouldPrintMessage: () => true,
-            },
-            'should-print-message-error',
-            true,
-        ],
-        [
-            'not throw error',
-            'console.error() is called',
-            {
-                shouldFailOnError: () => false,
-                shouldPrintMessage: () => true,
-            },
-            'should-print-message-no-error',
-            false,
-        ],
-    ])(
-        'should %s when %s with options %s',
-        async (msgA, msgB, options, fixture, isErrorThrown) => {
-            const { stderr } = await runFixture(fixture);
-            expect(stderr).toEqual(
-                isErrorThrown
-                    ? expect.stringContaining(errorThrownMessage())
-                    : expect.not.stringContaining(errorThrownMessage())
-            );
-        }
-    );
+    });
+
 });

--- a/vite.config.js
+++ b/vite.config.js
@@ -25,7 +25,6 @@ export default defineConfig({
     },
     plugins: [dts({ insertTypesEntry: true })],
     test: {
-        environment: 'node',
         globals: true,
         mockReset: true,
         restoreMocks: true,

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # yarn lockfile v1
 
 
-"@babel/code-frame@^7.0.0":
+"@babel/code-frame@^7.0.0", "@babel/code-frame@^7.10.4":
   version "7.27.1"
   resolved "https://registry.yarnpkg.com/@babel/code-frame/-/code-frame-7.27.1.tgz#200f715e66d52a23b221a9435534a91cc13ad5be"
   integrity sha512-cjQ7ZlQ0Mv3b47hABuTevyTuYN4i+loJKGeV9flcCgIK37cCXRh+L1bd3iBHlynerhQ7BhCkn2BPbQUL+rGqFg==
@@ -27,6 +27,11 @@
   integrity sha512-jVZGvOxOuNSsuQuLRTh13nU0AogFlw32w/MT+LV6D3sP5WdbW61E77RnkbaO2dUvmPAYrBDJXGn5gGS6tH4j8g==
   dependencies:
     "@babel/types" "^7.28.0"
+
+"@babel/runtime@^7.12.5":
+  version "7.28.3"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.3.tgz#75c5034b55ba868121668be5d5bb31cc64e6e61a"
+  integrity sha512-9uIQ10o0WGdpP6GDhXcdOJPJuDgFtIDtN/9+ArJQ2NAfAmiuhTQdzkaTGR33v43GYS2UrSA0eX2pPPHoFVvpxA==
 
 "@babel/types@^7.28.0":
   version "7.28.2"
@@ -489,6 +494,11 @@
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
 
+"@polka/url@^1.0.0-next.24":
+  version "1.0.0-next.29"
+  resolved "https://registry.yarnpkg.com/@polka/url/-/url-1.0.0-next.29.tgz#5a40109a1ab5f84d6fd8fc928b19f367cbe7e7b1"
+  integrity sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==
+
 "@rollup/pluginutils@^5.1.4":
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/@rollup/pluginutils/-/pluginutils-5.2.0.tgz#eac25ca5b0bdda4ba735ddaca5fbf26bd435f602"
@@ -638,10 +648,34 @@
     argparse "~1.0.9"
     string-argv "~0.3.1"
 
+"@testing-library/dom@^10.4.0":
+  version "10.4.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/dom/-/dom-10.4.1.tgz#d444f8a889e9a46e9a3b4f3b88e0fcb3efb6cf95"
+  integrity sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==
+  dependencies:
+    "@babel/code-frame" "^7.10.4"
+    "@babel/runtime" "^7.12.5"
+    "@types/aria-query" "^5.0.1"
+    aria-query "5.3.0"
+    dom-accessibility-api "^0.5.9"
+    lz-string "^1.5.0"
+    picocolors "1.1.1"
+    pretty-format "^27.0.2"
+
+"@testing-library/user-event@^14.6.1":
+  version "14.6.1"
+  resolved "https://registry.yarnpkg.com/@testing-library/user-event/-/user-event-14.6.1.tgz#13e09a32d7a8b7060fe38304788ebf4197cd2149"
+  integrity sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==
+
 "@types/argparse@1.0.38":
   version "1.0.38"
   resolved "https://registry.yarnpkg.com/@types/argparse/-/argparse-1.0.38.tgz#a81fd8606d481f873a3800c6ebae4f1d768a56a9"
   integrity sha512-ebDJ9b0e702Yr7pWgB0jzm+CX4Srzz8RcXtLJDJB+BSccqMa36uyH/zUsSYao5+BD1ytv3k3rPYCq4mAE1hsXA==
+
+"@types/aria-query@^5.0.1":
+  version "5.0.4"
+  resolved "https://registry.yarnpkg.com/@types/aria-query/-/aria-query-5.0.4.tgz#1a31c3d378850d2778dabb6374d036dcba4ba708"
+  integrity sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==
 
 "@types/chai@^5.2.2":
   version "5.2.2"
@@ -786,6 +820,20 @@
   dependencies:
     "@typescript-eslint/types" "8.38.0"
     eslint-visitor-keys "^4.2.1"
+
+"@vitest/browser@3.2.4":
+  version "3.2.4"
+  resolved "https://registry.yarnpkg.com/@vitest/browser/-/browser-3.2.4.tgz#4238600dc8343b8a9c032266c743f7d38ae3da84"
+  integrity sha512-tJxiPrWmzH8a+w9nLKlQMzAKX/7VjFs50MWgcAj7p9XQ7AQ9/35fByFYptgPELyLw+0aixTnC4pUWV+APcZ/kw==
+  dependencies:
+    "@testing-library/dom" "^10.4.0"
+    "@testing-library/user-event" "^14.6.1"
+    "@vitest/mocker" "3.2.4"
+    "@vitest/utils" "3.2.4"
+    magic-string "^0.30.17"
+    sirv "^3.0.1"
+    tinyrainbow "^2.0.0"
+    ws "^8.18.2"
 
 "@vitest/expect@3.2.4":
   version "3.2.4"
@@ -1014,6 +1062,11 @@ ansi-styles@^4.0.0, ansi-styles@^4.1.0:
   dependencies:
     color-convert "^2.0.1"
 
+ansi-styles@^5.0.0:
+  version "5.2.0"
+  resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
+  integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
+
 argparse@^2.0.1:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/argparse/-/argparse-2.0.1.tgz#246f50f3ca78a3240f6c997e8a9bd1eac49e4b38"
@@ -1025,6 +1078,13 @@ argparse@~1.0.9:
   integrity sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==
   dependencies:
     sprintf-js "~1.0.2"
+
+aria-query@5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/aria-query/-/aria-query-5.3.0.tgz#650c569e41ad90b51b3d7df5e5eed1c7549c103e"
+  integrity sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==
+  dependencies:
+    dequal "^2.0.3"
 
 array-ify@^1.0.0:
   version "1.0.0"
@@ -1483,6 +1543,11 @@ deep-is@^0.1.3:
   resolved "https://registry.yarnpkg.com/deep-is/-/deep-is-0.1.4.tgz#a6f2dce612fadd2ef1f519b73551f17e85199831"
   integrity sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ==
 
+dequal@^2.0.3:
+  version "2.0.3"
+  resolved "https://registry.yarnpkg.com/dequal/-/dequal-2.0.3.tgz#2644214f1997d39ed0ee0ece72335490a7ac67be"
+  integrity sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==
+
 detect-indent@^6.0.0:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/detect-indent/-/detect-indent-6.1.0.tgz#592485ebbbf6b3b1ab2be175c8393d04ca0d57e6"
@@ -1492,6 +1557,11 @@ detect-newline@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/detect-newline/-/detect-newline-3.1.0.tgz#576f5dfc63ae1a192ff192d8ad3af6308991b651"
   integrity sha512-TLz+x/vEXm/Y7P7wn1EJFNLxYpUD4TgMosxY6fAVJUnJMbupHBOncxyWUG9OpTaH9EBD7uFI5LfEgmMOc54DsA==
+
+dom-accessibility-api@^0.5.9:
+  version "0.5.16"
+  resolved "https://registry.yarnpkg.com/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz#5a7429e6066eb3664d911e33fb0e45de8eb08453"
+  integrity sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==
 
 dot-prop@^5.1.0:
   version "5.3.0"
@@ -1820,6 +1890,11 @@ fs-extra@~11.3.0:
     graceful-fs "^4.2.0"
     jsonfile "^6.0.1"
     universalify "^2.0.0"
+
+fsevents@2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@~2.3.2, fsevents@~2.3.3:
   version "2.3.3"
@@ -2336,6 +2411,11 @@ lru-cache@^6.0.0:
   dependencies:
     yallist "^4.0.0"
 
+lz-string@^1.5.0:
+  version "1.5.0"
+  resolved "https://registry.yarnpkg.com/lz-string/-/lz-string-1.5.0.tgz#c1ab50f77887b712621201ba9fd4e3a6ed099941"
+  integrity sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==
+
 magic-string@^0.30.17:
   version "0.30.17"
   resolved "https://registry.yarnpkg.com/magic-string/-/magic-string-0.30.17.tgz#450a449673d2460e5bbcfba9a61916a1714c7453"
@@ -2442,6 +2522,11 @@ modify-values@^1.0.0:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/modify-values/-/modify-values-1.0.1.tgz#b3939fa605546474e3e3e3c63d64bd43b4ee6022"
   integrity sha512-xV2bxeN6F7oYjZWTe/YPAy6MN2M+sL4u/Rlm2AHCIVGfo2p1yGmBHQ6vHehl4bRTZBdHu3TSkWdYgkwpYzAGSw==
+
+mrmime@^2.0.0:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/mrmime/-/mrmime-2.0.1.tgz#bc3e87f7987853a54c9850eeb1f1078cd44adddc"
+  integrity sha512-Y3wQdFg2Va6etvQ5I82yUhGdsKrcYox6p7FfL1LbK2J4V01F9TGlepTIhnK24t7koZibmg82KGglhA1XK5IsLQ==
 
 ms@^2.1.3:
   version "2.1.3"
@@ -2645,7 +2730,7 @@ pathval@^2.0.0:
   resolved "https://registry.yarnpkg.com/pathval/-/pathval-2.0.1.tgz#8855c5a2899af072d6ac05d11e46045ad0dc605d"
   integrity sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==
 
-picocolors@^1.1.1:
+picocolors@1.1.1, picocolors@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/picocolors/-/picocolors-1.1.1.tgz#3d321af3eab939b083c8f929a1d12cda81c26b6b"
   integrity sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==
@@ -2688,6 +2773,20 @@ pkg-types@^2.0.1:
     exsolve "^1.0.7"
     pathe "^2.0.3"
 
+playwright-core@1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.55.0.tgz#ec8a9f8ef118afb3e86e0f46f1393e3bea32adf4"
+  integrity sha512-GvZs4vU3U5ro2nZpeiwyb0zuFaqb9sUiAJuyrWpcGouD8y9/HLgGbNRjIph7zU9D3hnPaisMl9zG9CgFi/biIg==
+
+playwright@^1.55.0:
+  version "1.55.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.55.0.tgz#7aca7ac3ffd9e083a8ad8b2514d6f9ba401cc78b"
+  integrity sha512-sdCWStblvV1YU909Xqx0DhOjPZE4/5lJsIS84IfN9dAZfcl/CIZ5O8l3o0j7hPMjDvqoTF8ZUcc+i/GL5erstA==
+  dependencies:
+    playwright-core "1.55.0"
+  optionalDependencies:
+    fsevents "2.3.2"
+
 postcss@^8.5.6:
   version "8.5.6"
   resolved "https://registry.yarnpkg.com/postcss/-/postcss-8.5.6.tgz#2825006615a619b4f62a9e7426cc120b349a8f3c"
@@ -2706,6 +2805,15 @@ prettier@3.6.2:
   version "3.6.2"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-3.6.2.tgz#ccda02a1003ebbb2bfda6f83a074978f608b9393"
   integrity sha512-I7AIg5boAr5R0FFtJ6rCfD+LFsWHp81dolrFD8S79U9tb8Az2nGrJncnMSnys+bpQJfRUzqs9hnA81OAA3hCuQ==
+
+pretty-format@^27.0.2:
+  version "27.5.1"
+  resolved "https://registry.yarnpkg.com/pretty-format/-/pretty-format-27.5.1.tgz#2181879fdea51a7a5851fb39d920faa63f01d88e"
+  integrity sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==
+  dependencies:
+    ansi-regex "^5.0.1"
+    ansi-styles "^5.0.0"
+    react-is "^17.0.1"
 
 process-nextick-args@~2.0.0:
   version "2.0.1"
@@ -2736,6 +2844,11 @@ quick-lru@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/quick-lru/-/quick-lru-4.0.1.tgz#5b8878f113a58217848c6482026c73e1ba57727f"
   integrity sha512-ARhCpm70fzdcvNQfPoy49IaanKkTlRWF2JMzqhcJbhSFRZv7nPTvZJdcY7301IPmvW+/p0RgIWnQDLJxifsQ7g==
+
+react-is@^17.0.1:
+  version "17.0.2"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-17.0.2.tgz#e691d4a8e9c789365655539ab372762b0efb54f0"
+  integrity sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==
 
 read-pkg-up@^3.0.0:
   version "3.0.0"
@@ -2921,6 +3034,15 @@ siginfo@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/siginfo/-/siginfo-2.0.0.tgz#32e76c70b79724e3bb567cb9d543eb858ccfaf30"
   integrity sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==
+
+sirv@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/sirv/-/sirv-3.0.1.tgz#32a844794655b727f9e2867b777e0060fbe07bf3"
+  integrity sha512-FoqMu0NCGBLCcAkS1qA+XJIQTR6/JHfQXl+uGteNCQ76T91DMUjPa9xfmeqMY3z80nLSg9yQmNjK0Px6RWsH/A==
+  dependencies:
+    "@polka/url" "^1.0.0-next.24"
+    mrmime "^2.0.0"
+    totalist "^3.0.0"
 
 source-map-js@^1.2.1:
   version "1.2.1"
@@ -3177,6 +3299,11 @@ to-regex-range@^5.0.1:
   dependencies:
     is-number "^7.0.0"
 
+totalist@^3.0.0:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/totalist/-/totalist-3.0.1.tgz#ba3a3d600c915b1a97872348f79c127475f6acf8"
+  integrity sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==
+
 trim-newlines@^3.0.0:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/trim-newlines/-/trim-newlines-3.0.1.tgz#260a5d962d8b752425b32f3a7db0dcacd176c144"
@@ -3386,6 +3513,11 @@ wrap-ansi@^7.0.0:
     ansi-styles "^4.0.0"
     string-width "^4.1.0"
     strip-ansi "^6.0.0"
+
+ws@^8.18.2:
+  version "8.18.3"
+  resolved "https://registry.yarnpkg.com/ws/-/ws-8.18.3.tgz#b56b88abffde62791c639170400c93dcb0c95472"
+  integrity sha512-PEIGCY5tSlUt50cqyMXfCzX+oOPqN0vuGqWzbcJ2xvnkzkq46oOpz7dQaTDBdfICb4N14+GARUDw2XV2N4tvzg==
 
 xtend@~4.0.1:
   version "4.0.2"


### PR DESCRIPTION
### Related to
[Issue #115](https://github.com/thomasbrodusch/vitest-fail-on-console/issues/115)

### Notes
Replaces the dependency on node with the equivalent format function in vitest

### Types of changes
-   [x]   :bug: Bug fix


### Maintainability & Security
-   [x]   🧪  unit test



