### PR TITLE
fix: fix typo in peerDependencies for @vitest/utils

### DIFF
--- a/package.json
+++ b/package.json
@@ -63,7 +63,7 @@
     "chalk": "^5.4.1"
   },
   "peerDependencies": {
-    "@vitest/util": ">=0.26.2",
+    "@vitest/utils": ">=0.26.2",
     "vite": ">=4.5.2",
     "vitest": ">=0.26.2"
   }


### PR DESCRIPTION
### Related to
PR #136 

### Notes
When updating to the newest version we got an error because `@vitest/util` does not exist in NPM. It should be [`@vitest/utils`](https://www.npmjs.com/package/@vitest/utils). This can also be seen in the import; https://github.com/thomasbrodusch/vitest-fail-on-console/blob/267606db1d93d5be744aaa8173d7ca5540016939/src/index.ts#L3

```
npm warn ERESOLVE overriding peer dependency
npm warn While resolving: vitest-fail-on-console@0.10.0
npm warn Found: @vitest/util@undefined
npm warn node_modules/@vitest/util
npm warn
npm warn Could not resolve dependency:
npm warn peer @vitest/util@">=0.26.2" from vitest-fail-on-console@0.10.0
npm warn node_modules/vitest-fail-on-console
npm warn   dev vitest-fail-on-console@"0.10.0" from the root project
npm error code E404
npm error 404 Not Found - GET https://registry.npmjs.org/@vitest%2futil - Not found
npm error 404
npm error 404  The requested resource '@vitest/util@>=0.26.2' could not be found or you do not have permission to access it.
npm error 404
npm error 404 Note that you can also install from a
npm error 404 tarball, folder, http url, or git url.
npm error A complete log of this run can be found in: /builds/XXX/renovate-runner/renovate/cache/others/npm/_logs/2025-08-26T16_10_23_021Z-debug-0.log
```

### Types of changes
-   [X]   :bug: Bug fix
-   [ ]   :boom: Breaking change
-   [ ]   :sparkles: New feature
-   [ ]   :recycle: Refactoring
-   [ ]   :book: Documentation



