### PR TITLE
fix: Aligned ErrorMessageFunction with README

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ There is several changes between `jest-fail-on-console` and `vitest-fail-on-cons
 - refactoring of the whole codebase
 - refactoring of test/specs
 
-This repository has been developed and publish to keep and maintain a Vitest version 
+This repository has been developed and publish to keep and maintain a Vitest version
 of the original idea behind `jest-fail-on-console` credited at the bottom of this file.
 
 ## Install
@@ -88,9 +88,9 @@ Use this if you want to override the default error message of this library.
 
 ```ts
 // signature
-type errorMessage = (
+type ErrorMessageFunction = (
   methodName: 'assert' | 'debug' | 'error' | 'info' | 'log' | 'warn',
-  bold: (string: string) => string
+  bold: (text: string) => string
 ) => string
 ```
 
@@ -208,7 +208,7 @@ failOnConsole({
     if (ignoreNameList.includes(testName)) {
       return true
     }
-    
+
     return false
   },
 })

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vitest-fail-on-console",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "description": "Utility to make vitest tests fail when console.error() or console.warn() are used",
   "scripts": {
     "prebuild": "rm -rf dist",

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,16 +4,17 @@ import { format as vitestFormat } from "@vitest/utils"
 import {
     ConsoleCallStacks,
     ConsoleMethod,
+    ErrorMessageFunction,
     VitestFailOnConsoleFunction,
 } from './types';
 
 const LINE_RETURN = '\n';
-const defaultErrorMessage = (methodName: ConsoleMethod) =>
-    `vitest-fail-on-console > Expected test not to call ${chalk.bold(
+const defaultErrorMessage: ErrorMessageFunction = (methodName, bold) =>
+    `vitest-fail-on-console > Expected test not to call ${bold(
         `console.${methodName}()`
     )}.
-    If the ${methodName} is expected, test for it explicitly by mocking it out using: 
-    ${chalk.bold(
+    If the ${methodName} is expected, test for it explicitly by mocking it out using:
+    ${bold(
         `vi.spyOn(console, '${methodName}').mockImplementation(() => {}) `
     )}
     and test that the warning occurs.`;
@@ -68,7 +69,7 @@ const init = (
                 }
             );
 
-            const message = errorMessage(methodName);
+            const message = errorMessage(methodName, chalk.bold);
             const doubleLineReturn = `${LINE_RETURN}${LINE_RETURN}`;
             throw new Error(
                 `${message}${doubleLineReturn}${messages.join(

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,7 +6,7 @@ type SkipTestFunction = ({
     testPath?: string;
 }) => boolean;
 
-type ErrorMessageFunction = (methodName: ConsoleMethod) => string;
+export type ErrorMessageFunction = (methodName: ConsoleMethod, bold: (text: string) => string) => string;
 
 type AllowMessageFunction = (
     message: string,

--- a/tests/fixtures/custom-error-message/index.spec.ts
+++ b/tests/fixtures/custom-error-message/index.spec.ts
@@ -1,0 +1,7 @@
+import consoleError from './index';
+import { describe, it, expect } from 'vitest';
+describe('console.error custom error message', () => {
+    it('does throw', () => {
+        expect(consoleError).toThrow();
+    });
+});

--- a/tests/fixtures/custom-error-message/index.ts
+++ b/tests/fixtures/custom-error-message/index.ts
@@ -1,0 +1,1 @@
+export default () => console.error('this is an error message');

--- a/tests/fixtures/custom-error-message/vitest.config.ts
+++ b/tests/fixtures/custom-error-message/vitest.config.ts
@@ -1,0 +1,8 @@
+import { defineConfig } from 'vitest/config';
+export default defineConfig({
+    test: {
+        environment: 'node',
+        globals: true,
+        setupFiles: ['./tests/fixtures/custom-error-message/vitest.setup.ts'],
+    },
+});

--- a/tests/fixtures/custom-error-message/vitest.setup.ts
+++ b/tests/fixtures/custom-error-message/vitest.setup.ts
@@ -1,0 +1,5 @@
+import vitestFailOnConsole from '../../../src/index';
+vitestFailOnConsole({
+    errorMessage: (methodName, bold) =>
+        `CUSTOM_ERROR_MESSAGE: do not call ${bold(`console.${methodName}()`)}`,
+});

--- a/tests/index.spec.ts
+++ b/tests/index.spec.ts
@@ -1,8 +1,10 @@
 import { exec } from 'child_process';
 
 describe('vitest-fail-on-console', () => {
-    const errorThrownMessage = () =>
-        `vitest-fail-on-console > Expected test not to call`;
+    const errorThrownMessage = (fixture?: string) =>
+        fixture === 'custom-error-message'
+            ? 'CUSTOM_ERROR_MESSAGE:'
+            : 'vitest-fail-on-console > Expected test not to call';
 
     const runFixture = async (fixtureName: string, args: string): Promise<{ stderr: string }> => {
         const fixtureDirectory = `./tests/fixtures/${fixtureName}/`;
@@ -117,14 +119,24 @@ describe('vitest-fail-on-console', () => {
                 'should-print-message-no-error',
                 false,
             ],
+            [
+                'throw error',
+                'console.error() is called',
+                {
+                    errorMessage: (methodName, bold) =>
+                        `CUSTOM_ERROR_MESSAGE: do not call ${bold(`console.${methodName}()`)}`,
+                },
+                'custom-error-message',
+                true,
+            ],
         ])(
             'should %s when %s with options %s',
             async (msgA, msgB, options, fixture, isErrorThrown) => {
                 const { stderr } = await runFixture(fixture, args);
                 expect(stderr).toEqual(
                     isErrorThrown
-                        ? expect.stringContaining(errorThrownMessage())
-                        : expect.not.stringContaining(errorThrownMessage())
+                        ? expect.stringContaining(errorThrownMessage(fixture))
+                        : expect.not.stringContaining(errorThrownMessage(fixture))
                 );
             }
         );


### PR DESCRIPTION
### Notes
The README documented `errorMessage` as accepting a `bold` formatter, but the implementation only passed `methodName`. This caused type errors for consumers who followed the docs

This PR aligns the implementation with the documented API (and `jest-fail-on-console`):

- `ErrorMessageFunction` now accepts `(methodName, bold) => string`
- `defaultErrorMessage` uses the injected `bold` helper instead of calling `chalk.bold` directly
- The library passes `chalk.bold` when invoking custom `errorMessage` callbacks
- `ErrorMessageFunction` is exported for consumers typing custom callbacks
- README updated with the correct `ErrorMessageFunction` signature
- Added `custom-error-message` test fixture
- Version bumped to `0.10.2`

### Types of changes
-   [x]   :bug: Bug fix
-   [ ]   :boom: Breaking change
-   [ ]   :sparkles: New feature
-   [ ]   :recycle: Refactoring
-   [x]   :book: Documentation

### Maintainability & Security
-   [x]   🧪  unit test